### PR TITLE
Add support for IServiceProvider in exception handling

### DIFF
--- a/DalSoft.Hosting.BackgroundQueue/DependencyInjection/Extensions.cs
+++ b/DalSoft.Hosting.BackgroundQueue/DependencyInjection/Extensions.cs
@@ -8,7 +8,13 @@ namespace DalSoft.Hosting.BackgroundQueue.DependencyInjection
     {
         public static void AddBackgroundQueue(this IServiceCollection services, Action<Exception> onException, int maxConcurrentCount=1, int millisecondsToWaitBeforePickingUpTask = 1000)
         {
-            services.AddSingleton(new BackgroundQueue(onException, maxConcurrentCount, millisecondsToWaitBeforePickingUpTask));
+            services.AddSingleton(serivceProvider => new BackgroundQueue(((provider, exception) => onException(exception)), maxConcurrentCount, millisecondsToWaitBeforePickingUpTask, serivceProvider));
+            services.AddSingleton<IHostedService, BackgroundQueueService>();
+        }
+
+        public static void AddBackgroundQueue(this IServiceCollection services, Action<IServiceProvider, Exception> onException, int maxConcurrentCount = 1, int millisecondsToWaitBeforePickingUpTask = 1000)
+        {
+            services.AddSingleton(serivceProvider => new BackgroundQueue(onException, maxConcurrentCount, millisecondsToWaitBeforePickingUpTask, serivceProvider));
             services.AddSingleton<IHostedService, BackgroundQueueService>();
         }
     }


### PR DESCRIPTION
- added another extension method to support passing of IServiceProvider when handling exceptions

- added IServiceProvider parameter to the BackgroundQueue class to support new extension method

Now user can access services when handling exceptions, like this

```
services.AddBackgroundQueue(maxConcurrentCount: 1, millisecondsToWaitBeforePickingUpTask: 1000,
    onException: (_, exception) =>
    {
        _.GetService<YourLogger>().LogError(exception, "There was an error in the background queue.");
    });
```