### PR TITLE
Add dynamic cron scheduler (v2.1.0) + harden queue shutdown

### DIFF
--- a/DalSoft.Hosting.BackgroundQueue.Test/BackgroundQueueServiceTests.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Test/BackgroundQueueServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,12 +12,25 @@ namespace DalSoft.Hosting.BackgroundQueue.Test;
 
 public class BackgroundQueueServiceTests
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    // Polls a condition instead of sleeping a fixed amount, so the tests don't race the timer under load.
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition() && stopwatch.Elapsed < Timeout)
+        {
+            await Task.Delay(10, CancellationToken.None);
+        }
+    }
+
     [Fact]
     public async Task Queue20BackgroundTasks_WhenBackgroundTasksExistInQueue_ConcurrentCountIsGreaterThan1()
     {
         var serviceStopCancellationToken = new CancellationTokenSource();
         var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
         var mockServiceScope = new Mock<IServiceScope>();
+        var gate = new TaskCompletionSource();
 
         var queue = new BackgroundQueue
         (
@@ -27,37 +41,32 @@ public class BackgroundQueueServiceTests
         );
 
         var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        var highwaterMark = 0;
 
-        // queue background tasks
+        // Tasks park on the gate so they stay in-flight - concurrency climbs deterministically rather than
+        // depending on whether a short Task.Delay happens to overlap the timer tick.
         for (var i = 0; i < 20; i++)
         {
-            queue.Enqueue(async cancellationToken =>
-            {
-                highwaterMark = Math.Max(queue.ConcurrentCount, highwaterMark);
-                await Task.Delay(5, cancellationToken);
-            });
+            queue.Enqueue(async cancellationToken => await gate.Task.WaitAsync(cancellationToken));
         }
-            
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), TestContext.Current.CancellationToken);
-            
-        // wait for all tasks to be processed
-        while(queue.Count > 0)
-        {
-            await Task.Delay(20, TestContext.Current.CancellationToken);
-        }
-            
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => queue.ConcurrentCount > 1);
+
         // Check that tasks run concurrently up to the maxConcurrentCount.
-        highwaterMark.Should().BeGreaterThan(1);
+        queue.ConcurrentCount.Should().BeGreaterThan(1);
+
+        gate.TrySetResult();
+        serviceStopCancellationToken.Cancel();
     }
-    
+
     [Fact(DisplayName = "Check That background tasks are processed up to the MaxConcurrentCount")]
     public async Task Queue20BackgroundTasks_WhenMaxConcurrentCount10_ConcurrentCountShouldBe10AndCountShouldBe10()
     {
         var serviceStopCancellationToken = new CancellationTokenSource();
         var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
         var mockServiceScope = new Mock<IServiceScope>();
+        var gate = new TaskCompletionSource();
 
         var queue = new BackgroundQueue
         (
@@ -68,21 +77,27 @@ public class BackgroundQueueServiceTests
         );
 
         var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        // queue background tasks
+
+        // Gated tasks stay running, so once 10 are picked up the service stops dequeuing (at MaxConcurrentCount)
+        // leaving exactly 10 in the queue - a stable state to assert against.
         for (var i = 0; i < 20; i++)
         {
-            queue.Enqueue(async cancellationToken => await Task.Delay(200, cancellationToken));
+            queue.Enqueue(async cancellationToken => await gate.Task.WaitAsync(cancellationToken));
         }
 
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), TestContext.Current.CancellationToken);
         queue.Count.Should().Be(20);
-        // wait for tasks to be picked up off the queue
-        await Task.Delay(200, serviceStopCancellationToken.Token);
-        queue.Count.Should().Be(10);
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => queue.ConcurrentCount == 10);
+
         queue.ConcurrentCount.Should().Be(10);
+        queue.Count.Should().Be(10);
+
+        gate.TrySetResult();
+        serviceStopCancellationToken.Cancel();
     }
-    
+
     [Fact]
     public async Task Queue20BackgroundTasks_WhenMaxConcurrentCount10AndServiceIsStoppedViaToken_ConcurrentCountShouldBeAndCountShould20()
     {
@@ -105,11 +120,12 @@ public class BackgroundQueueServiceTests
             queue.Enqueue( _ => Task.CompletedTask);
         }
 
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), TestContext.Current.CancellationToken);
+        // Stop before the service ever ticks, so nothing is dequeued.
         serviceStopCancellationToken.Cancel();
-        // wait for tasks to be picked up off the queue
-        await Task.Delay(200, TestContext.Current.CancellationToken);
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        // give a stopped service a chance to (incorrectly) pick anything up
+        await Task.Delay(50, CancellationToken.None);
         queue.Count.Should().Be(20);
         queue.ConcurrentCount.Should().Be(0);
     }
@@ -133,21 +149,19 @@ public class BackgroundQueueServiceTests
             maxConcurrentCount: 10,
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => throw new Exception(expectedExceptionMessage));
-        
-        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
-        queue.Enqueue(async _ => await Task.CompletedTask);
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), TestContext.Current.CancellationToken);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, TestContext.Current.CancellationToken);
-        
+        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
+
+        queue.Enqueue(async _ => await Task.CompletedTask);
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => exceptionThrown);
+
         exceptionThrown.Should().Be(true);
         actualExceptionMessage.Should().Be(expectedExceptionMessage);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_CreateAsyncScopeThrowsExceptionAndITryToAccessServiceProviderViaOnException_ExceptionIsThrowTellingUserCreateAsyncScopeFailed()
     {
@@ -174,21 +188,19 @@ public class BackgroundQueueServiceTests
             maxConcurrentCount: 10,
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => throw new Exception());
-        
-        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
-        queue.Enqueue(async _ => await Task.CompletedTask);
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), TestContext.Current.CancellationToken);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, TestContext.Current.CancellationToken);
-        
+        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
+
+        queue.Enqueue(async _ => await Task.CompletedTask);
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => exceptionThrown);
+
         exceptionThrown.Should().Be(true);
         actualExceptionMessage.Should().Be(ServiceScopeWithException.CreateAsyncScopeFailedMessage);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_ThrowsException_OnExceptionIsCalled()
     {
@@ -210,58 +222,57 @@ public class BackgroundQueueServiceTests
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => new AsyncServiceScope(mockServiceScope.Object)
         );
-        
-        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
-        queue.Enqueue(_ => throw new Exception(expectedExceptionMessage));
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), serviceStopCancellationToken.Token);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, serviceStopCancellationToken.Token);
-        
+        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
+
+        queue.Enqueue(_ => throw new Exception(expectedExceptionMessage));
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => exceptionThrown);
+
         exceptionThrown.Should().Be(true);
         actualExceptionMessage.Should().Be(expectedExceptionMessage);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_ThrowsException_ICanGetServicesViaOnException()
     {
         var serviceStopCancellationToken = new CancellationTokenSource();
         var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
         var mockServiceScope = new Mock<IServiceScope>();
+        var onExceptionCalled = new TaskCompletionSource();
 
         var queue = new BackgroundQueue
         (
             onException: (_, serviceScope) =>
             {
                 var scopeServiceProvider = serviceScope.ServiceProvider;
+                onExceptionCalled.TrySetResult();
             },
             maxConcurrentCount: 10,
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => new AsyncServiceScope(mockServiceScope.Object)
         );
-        
-        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
-        queue.Enqueue(_ => throw new Exception());
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), serviceStopCancellationToken.Token);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, serviceStopCancellationToken.Token);
-        
+        var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
+
+        queue.Enqueue(_ => throw new Exception());
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await onExceptionCalled.Task.WaitAsync(Timeout);
+
         mockServiceScope.Verify(serviceScope => serviceScope.ServiceProvider, Times.Once);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_WhenDequeued_ServiceStopCancellationTokenIsPassedToBackgroundTask()
     {
         var serviceStopCancellationToken = new CancellationTokenSource();
         var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
         var mockServiceScope = new Mock<IServiceScope>();
+        var taskPickedUp = new TaskCompletionSource();
 
         var queue = new BackgroundQueue
         (
@@ -270,35 +281,39 @@ public class BackgroundQueueServiceTests
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => new AsyncServiceScope(mockServiceScope.Object)
         );
-        
+
         var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
         var taskCancelled = false;
         serviceStopCancellationToken.Token.Register(() =>
-        { 
+        {
             taskCancelled = true;
         });
         queue.Enqueue(async (cancellationToken, _) =>
         {
+            taskPickedUp.TrySetResult();
             while (!taskCancelled)
             {
                 await Task.Delay(10, CancellationToken.None);
             }
         });
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), serviceStopCancellationToken.Token);
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, CancellationToken.None);
+
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        // wait until the task is actually running before stopping the service
+        await taskPickedUp.Task.WaitAsync(Timeout);
         serviceStopCancellationToken.Cancel();
+
+        await WaitUntilAsync(() => taskCancelled);
         taskCancelled.Should().Be(true);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_WhenDequeued_ICanGetServices()
     {
         var serviceStopCancellationToken = new CancellationTokenSource();
         var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
         var mockServiceScope = new Mock<IServiceScope>();
+        var ran = new TaskCompletionSource();
 
         var queue = new BackgroundQueue
         (
@@ -307,24 +322,23 @@ public class BackgroundQueueServiceTests
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => new AsyncServiceScope(mockServiceScope.Object)
         );
-        
+
         var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
+
         queue.Enqueue( (_, serviceScope) =>
         {
             var serviceProvider = serviceScope.ServiceProvider;
+            ran.TrySetResult();
             return Task.CompletedTask;
         });
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), serviceStopCancellationToken.Token);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, serviceStopCancellationToken.Token);
-        
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await ran.Task.WaitAsync(Timeout);
+
         mockServiceScope.Verify(serviceScope => serviceScope.ServiceProvider, Times.Once);
     }
-    
+
     [Fact]
     public async Task QueueBackgroundTask_WhenQueuedAndDeQueued_CountIsCorrect()
     {
@@ -339,19 +353,17 @@ public class BackgroundQueueServiceTests
             millisecondsToWaitBeforePickingUpTask: 10,
             fakeCreateAsyncScope: () => new AsyncServiceScope(mockServiceScope.Object)
         );
-        
+
         var queueService = new BackgroundQueueService(queue, mockServiceScopeFactory.Object);
-        
+
         queue.Enqueue( (_, serviceScope) => Task.CompletedTask);
 
         queue.Count.Should().Be(1);
-        
-        // process background tasks
-        var runningService = Task.Run(async () => await queueService.StartAsync(serviceStopCancellationToken.Token), serviceStopCancellationToken.Token);
 
-        // wait for an attempt to pick a task up off the queue
-        await Task.Delay(30, serviceStopCancellationToken.Token);
-        
+        await queueService.StartAsync(serviceStopCancellationToken.Token);
+
+        await WaitUntilAsync(() => queue.Count == 0);
+
         queue.Count.Should().Be(0);
     }
 }

--- a/DalSoft.Hosting.BackgroundQueue.Test/DalSoft.Hosting.BackgroundQueue.Test.csproj
+++ b/DalSoft.Hosting.BackgroundQueue.Test/DalSoft.Hosting.BackgroundQueue.Test.csproj
@@ -6,10 +6,14 @@
     <IsPackable>false</IsPackable>
 
     <RootNamespace>DalSoft.Hosting.BackgroundQueue.Test</RootNamespace>
+    <!-- xUnit1051 asks every CancellationToken-accepting call to thread TestContext.Current.CancellationToken;
+         not meaningful for these fast, deterministic scheduler unit tests. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.71" />
     <PackageReference Include="xunit.v3" Version="0.3.0-pre.18" />

--- a/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/JobSchedulerTests.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/JobSchedulerTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+using FluentAssertions;
+using Xunit;
+
+namespace DalSoft.Hosting.BackgroundQueue.Test.Scheduling;
+
+public class JobSchedulerTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static (JobScheduler scheduler, CountingScheduleStore store, FakeClock clock) Create()
+    {
+        var store = new CountingScheduleStore();
+        var clock = new FakeClock(T0);
+        return (new JobScheduler(store, clock), store, clock);
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_AddsJob_ListsIt_AndWritesThroughToStore()
+    {
+        var (scheduler, store, _) = Create();
+
+        await scheduler.ScheduleAsync<RecordingInvocable>("daily", "0 0 * * *");
+
+        scheduler.Exists("daily").Should().BeTrue();
+        scheduler.List().Should().ContainSingle(job => job.Key == "daily");
+        store.UpsertCount.Should().Be(1);
+        // next occurrence after 2026-01-01 00:00:00 for "daily at midnight" is the next day
+        scheduler.List().Single().NextRunUtc.Should().Be(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_InvalidCron_Throws_AndDoesNotTouchStore()
+    {
+        var (scheduler, store, _) = Create();
+
+        var act = () => scheduler.ScheduleAsync<RecordingInvocable>("bad", "not a cron");
+
+        await act.Should().ThrowAsync<Exception>();
+        store.UpsertCount.Should().Be(0);
+        scheduler.Exists("bad").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_TypeThatIsNotInvocable_Throws()
+    {
+        var (scheduler, _, _) = Create();
+
+        var act = () => scheduler.ScheduleAsync("oops", "* * * * *", typeof(string));
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_SupportsSecondsPrecisionCron()
+    {
+        var (scheduler, _, _) = Create();
+
+        await scheduler.ScheduleAsync<RecordingInvocable>("everysecond", "* * * * * *");
+
+        scheduler.List().Single().NextRunUtc.Should().Be(T0.AddSeconds(1));
+    }
+
+    [Fact]
+    public async Task RescheduleAsync_ChangesCron_RecomputesNextRun_AndWritesThrough()
+    {
+        var (scheduler, store, _) = Create();
+        await scheduler.ScheduleAsync<RecordingInvocable>("job", "0 0 * * *"); // midnight -> 2026-01-02 00:00
+
+        await scheduler.RescheduleAsync("job", "0 12 * * *"); // noon -> 2026-01-01 12:00
+
+        scheduler.List().Single().NextRunUtc.Should().Be(new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+        store.UpsertCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RescheduleAsync_UnknownKey_Throws()
+    {
+        var (scheduler, _, _) = Create();
+
+        var act = () => scheduler.RescheduleAsync("nope", "0 0 * * *");
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_RemovesFromMemoryAndStore()
+    {
+        var (scheduler, store, _) = Create();
+        await scheduler.ScheduleAsync<RecordingInvocable>("job", "0 0 * * *");
+
+        var removed = await scheduler.RemoveAsync("job");
+
+        removed.Should().BeTrue();
+        scheduler.Exists("job").Should().BeFalse();
+        store.RemoveCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_UnknownKey_ReturnsFalse()
+    {
+        var (scheduler, _, _) = Create();
+
+        (await scheduler.RemoveAsync("nope")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReloadFromStoreAsync_RehydratesFromStore_AndDropsRemoved()
+    {
+        // Seed a store directly (as if a previous process / another writer persisted these).
+        var store = new CountingScheduleStore();
+        var clock = new FakeClock(T0);
+        var seeder = new JobScheduler(store, clock);
+        await seeder.ScheduleAsync<RecordingInvocable>("a", "0 0 * * *");
+        await seeder.ScheduleAsync<RecordingInvocable>("b", "0 0 * * *");
+
+        // A fresh scheduler instance starts empty, then loads from the same store.
+        var scheduler = new JobScheduler(store, clock);
+        scheduler.List().Should().BeEmpty();
+
+        await scheduler.ReloadFromStoreAsync();
+        scheduler.List().Select(j => j.Key).Should().BeEquivalentTo(new[] { "a", "b" });
+
+        // Remove one from the store, reload, and confirm it's dropped in memory.
+        await store.RemoveAsync("a");
+        await scheduler.ReloadFromStoreAsync();
+        scheduler.List().Select(j => j.Key).Should().BeEquivalentTo(new[] { "b" });
+    }
+
+    [Fact]
+    public async Task DueJobs_ReturnsOnlyJobsWhoseNextRunHasPassed()
+    {
+        var (scheduler, _, clock) = Create();
+        await scheduler.ScheduleAsync<RecordingInvocable>("everysecond", "* * * * * *"); // due at T0+1s
+
+        scheduler.DueJobs(clock.UtcNow).Should().BeEmpty();          // nothing due at T0
+        scheduler.DueJobs(T0.AddSeconds(1)).Select(j => j.Key).Should().ContainSingle().Which.Should().Be("everysecond");
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/ScheduledJobTests.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/ScheduledJobTests.cs
@@ -1,0 +1,64 @@
+using System;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+using FluentAssertions;
+using Xunit;
+
+namespace DalSoft.Hosting.BackgroundQueue.Test.Scheduling;
+
+public class ScheduledJobTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static ScheduledJob NewJob(string cron = "* * * * * *") => ScheduledJob.Create(
+        new ScheduleDefinition
+        {
+            Key = "k",
+            CronExpression = cron,
+            InvocableType = $"{typeof(RecordingInvocable).FullName}, {typeof(RecordingInvocable).Assembly.GetName().Name}"
+        },
+        T0);
+
+    [Fact]
+    public void TryBeginRun_PreventsOverlap_UntilEndRun()
+    {
+        var job = NewJob();
+
+        job.TryBeginRun().Should().BeTrue();   // first claim wins
+        job.TryBeginRun().Should().BeFalse();  // already running - overlap blocked
+        job.IsRunning.Should().BeTrue();
+
+        job.EndRun();
+
+        job.IsRunning.Should().BeFalse();
+        job.TryBeginRun().Should().BeTrue();   // can run again after finishing
+    }
+
+    [Fact]
+    public void AdvanceNextRun_MovesToNextOccurrenceAfterTheGivenTime()
+    {
+        var job = NewJob("0 0 * * *"); // daily midnight; created at T0 (midnight) => next is the following day
+        job.NextRunUtc.Should().Be(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        job.AdvanceNextRun(new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        job.NextRunUtc.Should().Be(new DateTime(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Create_ResolvesTimeZone_AndEvaluatesCronInIt()
+    {
+        // 30 minutes past midnight, evaluated in a +05:30 zone, is 19:00 UTC the previous day-relative.
+        var tz = TimeZoneInfo.FindSystemTimeZoneById(OperatingSystem.IsWindows() ? "India Standard Time" : "Asia/Kolkata");
+        var job = ScheduledJob.Create(
+            new ScheduleDefinition
+            {
+                Key = "tz",
+                CronExpression = "0 0 * * *", // local midnight in IST
+                InvocableType = $"{typeof(RecordingInvocable).FullName}, {typeof(RecordingInvocable).Assembly.GetName().Name}",
+                TimeZoneId = tz.Id
+            },
+            T0);
+
+        // IST midnight on 2026-01-01 is 2025-12-31 18:30 UTC (already past T0), so next is 2026-01-01 18:30 UTC.
+        job.NextRunUtc.Should().Be(new DateTime(2026, 1, 1, 18, 30, 0, DateTimeKind.Utc));
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/SchedulerHostedServiceTests.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/SchedulerHostedServiceTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace DalSoft.Hosting.BackgroundQueue.Test.Scheduling;
+
+public class SchedulerHostedServiceTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static (IServiceProvider provider, IJobScheduler scheduler, JobRecorder recorder, CountingScheduleStore store, FakeClock clock) Build()
+    {
+        var clock = new FakeClock(T0);
+        var store = new CountingScheduleStore();
+        var recorder = new JobRecorder();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ISystemClock>(clock);     // registered before AddBackgroundJobs so TryAdd keeps the fake
+        services.AddSingleton<IScheduleStore>(store);
+        services.AddSingleton(recorder);
+        services.AddBackgroundJobs(options => options.TickInterval = TimeSpan.FromMilliseconds(20));
+
+        var provider = services.BuildServiceProvider();
+        return (provider, provider.GetRequiredService<IJobScheduler>(), recorder, store, clock);
+    }
+
+    private static SchedulerHostedService HostedService(IServiceProvider provider)
+        => provider.GetServices<IHostedService>().OfType<SchedulerHostedService>().Single();
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return true;
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+        }
+        return condition();
+    }
+
+    [Fact]
+    public async Task ScheduledJob_Runs_WhenItBecomesDue()
+    {
+        var (provider, scheduler, recorder, _, clock) = Build();
+        await scheduler.ScheduleAsync<RecordingInvocable>("everysecond", "* * * * * *"); // due at T0 + 1s
+
+        var service = HostedService(provider);
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            clock.Advance(TimeSpan.FromSeconds(2)); // now past the first occurrence
+            (await WaitUntilAsync(() => recorder.Runs >= 1, TimeSpan.FromSeconds(3))).Should().BeTrue();
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Tick_NeverPollsTheStore_OnlyLoadsOnceAtStartup()
+    {
+        var (provider, scheduler, recorder, store, clock) = Build();
+        await scheduler.ScheduleAsync<RecordingInvocable>("everysecond", "* * * * * *");
+        store.UpsertCount.Should().Be(1); // the schedule write-through
+
+        var service = HostedService(provider);
+        await service.StartAsync(CancellationToken.None); // single startup load
+        try
+        {
+            // Advance the clock repeatedly so the every-second job becomes due several times,
+            // exercising many tick iterations in between.
+            for (var i = 0; i < 4; i++)
+            {
+                clock.Advance(TimeSpan.FromSeconds(1));
+                await Task.Delay(60, TestContext.Current.CancellationToken);
+            }
+            await WaitUntilAsync(() => recorder.Runs >= 3, TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        recorder.Runs.Should().BeGreaterThanOrEqualTo(3); // fired on multiple ticks
+        store.LoadCount.Should().Be(1);   // ONLY the startup load - the per-tick loop never touched the store
+        store.UpsertCount.Should().Be(1); // no writes happened on the tick either
+    }
+
+    [Fact]
+    public async Task ScheduledJob_ReceivesPayload_WhenItImplementsIInvocableWithPayload()
+    {
+        var (provider, scheduler, recorder, _, clock) = Build();
+        await scheduler.ScheduleAsync<RecordingInvocableWithPayload>("withpayload", "* * * * * *", payload: "hello-from-store");
+
+        var service = HostedService(provider);
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            clock.Advance(TimeSpan.FromSeconds(2));
+            (await WaitUntilAsync(() => recorder.Payloads.Count >= 1, TimeSpan.FromSeconds(3))).Should().BeTrue();
+            recorder.Payloads.Should().Contain("hello-from-store");
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task DynamicallyRemovedJob_StopsRunning_WithoutRestart()
+    {
+        var (provider, scheduler, recorder, _, clock) = Build();
+        await scheduler.ScheduleAsync<RecordingInvocable>("everysecond", "* * * * * *");
+
+        var service = HostedService(provider);
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            clock.Advance(TimeSpan.FromSeconds(2));
+            (await WaitUntilAsync(() => recorder.Runs >= 1, TimeSpan.FromSeconds(3))).Should().BeTrue();
+
+            await scheduler.RemoveAsync("everysecond");
+            var runsAtRemoval = recorder.Runs;
+
+            // Advance further; with the job removed it must not run again.
+            clock.Advance(TimeSpan.FromSeconds(5));
+            await Task.Delay(150, TestContext.Current.CancellationToken);
+
+            recorder.Runs.Should().Be(runsAtRemoval);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/SchedulerTestHelpers.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Test/Scheduling/SchedulerTestHelpers.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+namespace DalSoft.Hosting.BackgroundQueue.Test.Scheduling;
+
+/// <summary>A clock the test drives directly so scheduling is deterministic regardless of the real tick cadence.</summary>
+internal sealed class FakeClock : ISystemClock
+{
+    private long _ticks;
+
+    public FakeClock(DateTime start) => _ticks = start.Ticks;
+
+    public DateTime UtcNow => new(Volatile.Read(ref _ticks), DateTimeKind.Utc);
+
+    public void Set(DateTime utc) => Volatile.Write(ref _ticks, utc.Ticks);
+
+    public void Advance(TimeSpan delta) => Volatile.Write(ref _ticks, Volatile.Read(ref _ticks) + delta.Ticks);
+}
+
+/// <summary>Wraps an in-memory store and counts each call so tests can assert the store is never polled on the tick.</summary>
+internal sealed class CountingScheduleStore : IScheduleStore
+{
+    private readonly InMemoryScheduleStore _inner = new();
+
+    public int LoadCount;
+    public int UpsertCount;
+    public int RemoveCount;
+
+    public Task<IReadOnlyCollection<ScheduleDefinition>> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref LoadCount);
+        return _inner.LoadAsync(cancellationToken);
+    }
+
+    public Task UpsertAsync(ScheduleDefinition definition, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref UpsertCount);
+        return _inner.UpsertAsync(definition, cancellationToken);
+    }
+
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref RemoveCount);
+        return _inner.RemoveAsync(key, cancellationToken);
+    }
+}
+
+/// <summary>Shared, DI-injected sink so invocables can record what ran across per-run scopes.</summary>
+public sealed class JobRecorder
+{
+    private int _runs;
+    private readonly object _gate = new();
+    private readonly List<string> _payloads = new();
+
+    public int Runs => Volatile.Read(ref _runs);
+    public IReadOnlyList<string> Payloads { get { lock (_gate) return _payloads.ToArray(); } }
+
+    public void Record(string? payload)
+    {
+        Interlocked.Increment(ref _runs);
+        if (payload is not null)
+        {
+            lock (_gate) _payloads.Add(payload);
+        }
+    }
+}
+
+public sealed class RecordingInvocable : IInvocable
+{
+    private readonly JobRecorder _recorder;
+    public RecordingInvocable(JobRecorder recorder) => _recorder = recorder;
+
+    public Task Invoke()
+    {
+        _recorder.Record(null);
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class RecordingInvocableWithPayload : IInvocable, IInvocableWithPayload
+{
+    private readonly JobRecorder _recorder;
+    public RecordingInvocableWithPayload(JobRecorder recorder) => _recorder = recorder;
+
+    public string? Payload { get; set; }
+
+    public Task Invoke()
+    {
+        _recorder.Record(Payload);
+        return Task.CompletedTask;
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue/.editorconfig
+++ b/DalSoft.Hosting.BackgroundQueue/.editorconfig
@@ -1,0 +1,15 @@
+# Public API analyzer rules for the packaged library.
+# The PublicAPI.Shipped.txt / PublicAPI.Unshipped.txt files are the source of truth for the public surface,
+# so an accidental change to an existing public API fails the build instead of slipping into a release.
+[*.cs]
+
+# Hard-enforce backwards compatibility: these break the build if the public surface drifts from the API files.
+dotnet_diagnostic.RS0016.severity = error   # a public/protected member isn't declared in the API files
+dotnet_diagnostic.RS0017.severity = error   # the API files list a member that no longer exists
+dotnet_diagnostic.RS0024.severity = error   # a member was removed from the shipped (released) API
+dotnet_diagnostic.RS0025.severity = error   # a member is duplicated in the API files
+
+# Intentional design choices - silenced on purpose:
+dotnet_diagnostic.RS0041.severity = none    # legacy v2.0.x signatures are non-nullable (oblivious) by design
+dotnet_diagnostic.RS0026.severity = none    # the new ScheduleAsync overloads with optional params are deliberate
+dotnet_diagnostic.RS0027.severity = none    # ditto - overload-with-most-parameters guidance not applicable here

--- a/DalSoft.Hosting.BackgroundQueue/BackgroundQueue.cs
+++ b/DalSoft.Hosting.BackgroundQueue/BackgroundQueue.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,31 +17,34 @@ public class BackgroundQueue : IBackgroundQueue
     private int _concurrentCount;
     private readonly Action<Exception, AsyncServiceScope > _onException;
     private readonly ConcurrentQueue<Func<CancellationToken, AsyncServiceScope, Task>> _taskQueue = new();
-    
+
+    // Tracks the tasks currently being processed so the host can drain them on shutdown.
+    private readonly ConcurrentDictionary<Task, byte> _inFlight = new();
+
     // This is needed to keep things testable as CreateAsyncScope is at extension method.
     private readonly Func<AsyncServiceScope> _fakeCreateAsyncScope;
-    internal BackgroundQueue(Action<Exception, AsyncServiceScope> onException, int maxConcurrentCount, int millisecondsToWaitBeforePickingUpTask, Func<AsyncServiceScope> fakeCreateAsyncScope): 
+    internal BackgroundQueue(Action<Exception, AsyncServiceScope> onException, int maxConcurrentCount, int millisecondsToWaitBeforePickingUpTask, Func<AsyncServiceScope> fakeCreateAsyncScope):
         this(onException, maxConcurrentCount, millisecondsToWaitBeforePickingUpTask)
     {
         _fakeCreateAsyncScope = fakeCreateAsyncScope;
     }
-    
+
     internal const string MaxConcurrentCountExceptionMessage = "maxConcurrentCount must be at least 1";
     internal const string MillisecondsToWaitBeforePickingUpTaskExceptionMessage = "millisecondsToWaitBeforePickingUpTask cannot be < 10 Milliseconds";
-    
+
     public BackgroundQueue(Action<Exception, AsyncServiceScope> onException, int maxConcurrentCount, int millisecondsToWaitBeforePickingUpTask)
     {
         if (maxConcurrentCount < 1)
         {
-            throw new ArgumentException("maxConcurrentCount must be at least 1", nameof(maxConcurrentCount));
-        }
-        
-        if (millisecondsToWaitBeforePickingUpTask < 10)
-        {
-            throw new ArgumentException("millisecondsToWaitBeforePickingUpTask cannot be < 10 Milliseconds", nameof(millisecondsToWaitBeforePickingUpTask));
+            throw new ArgumentException(MaxConcurrentCountExceptionMessage, nameof(maxConcurrentCount));
         }
 
-        _onException = onException ?? ((ex, scope) => { }); 
+        if (millisecondsToWaitBeforePickingUpTask < 10)
+        {
+            throw new ArgumentException(MillisecondsToWaitBeforePickingUpTaskExceptionMessage, nameof(millisecondsToWaitBeforePickingUpTask));
+        }
+
+        _onException = onException ?? ((ex, scope) => { });
         MaxConcurrentCount = maxConcurrentCount;
         MillisecondsToWaitBeforePickingUpTask = millisecondsToWaitBeforePickingUpTask;
     }
@@ -49,46 +53,79 @@ public class BackgroundQueue : IBackgroundQueue
     {
         _taskQueue.Enqueue(task);
     }
-        
+
     public void Enqueue(Func<CancellationToken, Task> task)
     {
         // keep usage backwards compatible with < DalSoft.Hosting.BackgroundQueue v2.0.0
         _taskQueue.Enqueue((token, _) => task(token));
     }
-        
-    internal async Task Dequeue(CancellationToken serviceStopCancellationToken, IServiceScopeFactory serviceScopeFactory)
+
+    internal void Dequeue(CancellationToken serviceStopCancellationToken, IServiceScopeFactory serviceScopeFactory)
     {
-        if (_taskQueue.TryDequeue(out var nextTaskAction))
+        if (!_taskQueue.TryDequeue(out var nextTaskAction))
         {
-            try
-            {
-                await ProcessBackgroundTask(serviceStopCancellationToken, serviceScopeFactory, nextTaskAction);
-            }
-            catch (Exception e)
-            {
-                // *very* unlikely to happen, but if serviceScopeFactory.CreateAsyncScope() ever fails, we have no way letting the user know their task failed.
-                _onException(e, new AsyncServiceScope(new ServiceScopeWithException()));
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _concurrentCount);
-            }
+            return;
         }
 
-        await Task.CompletedTask;
+        // Kick off processing and track it so the service can wait for in-flight work to drain on shutdown.
+        var processing = ProcessBackgroundTask(serviceStopCancellationToken, serviceScopeFactory, nextTaskAction);
+
+        if (processing.IsCompleted)
+        {
+            return;
+        }
+
+        _inFlight[processing] = 0;
+        _ = processing.ContinueWith(
+            static (completed, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(completed, out _),
+            _inFlight,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
+
+    // Awaited by the host on shutdown so in-flight tasks aren't abandoned (and their scopes disposed underneath them).
+    internal Task WhenAllInFlightComplete() => Task.WhenAll(_inFlight.Keys.ToArray());
 
     private async Task ProcessBackgroundTask(CancellationToken serviceStopCancellationToken, IServiceScopeFactory serviceScopeFactory, Func<CancellationToken, AsyncServiceScope, Task> nextTaskAction)
     {
         Interlocked.Increment(ref _concurrentCount);
-        await using var asyncScope = _fakeCreateAsyncScope?.Invoke() ?? serviceScopeFactory.CreateAsyncScope();
         try
         {
-            await nextTaskAction(serviceStopCancellationToken, asyncScope);
+            try
+            {
+                await using var asyncScope = _fakeCreateAsyncScope?.Invoke() ?? serviceScopeFactory.CreateAsyncScope();
+                try
+                {
+                    await nextTaskAction(serviceStopCancellationToken, asyncScope);
+                }
+                catch (Exception e)
+                {
+                    SafeOnException(e, asyncScope);
+                }
+            }
+            catch (Exception e)
+            {
+                // *very* unlikely to happen, but if serviceScopeFactory.CreateAsyncScope() ever fails, we still let the user know their task failed.
+                SafeOnException(e, new AsyncServiceScope(new ServiceScopeWithException()));
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _onException(e, asyncScope);
+            Interlocked.Decrement(ref _concurrentCount);
+        }
+    }
+
+    private void SafeOnException(Exception exception, AsyncServiceScope scope)
+    {
+        try
+        {
+            _onException(exception, scope);
+        }
+        catch
+        {
+            // The user's onException handler threw. There's nowhere left to surface this, and we must not
+            // let it escape onto the processing task (where it would become an unobserved task exception).
         }
     }
 }

--- a/DalSoft.Hosting.BackgroundQueue/BackgroundQueueService.cs
+++ b/DalSoft.Hosting.BackgroundQueue/BackgroundQueueService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,18 +18,31 @@ public class BackgroundQueueService : BackgroundService
     }
 
     protected override async Task ExecuteAsync(CancellationToken serviceStopCancellationToken)
-    { 
+    {
         using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(_backgroundQueue.MillisecondsToWaitBeforePickingUpTask));
 
-        while (!serviceStopCancellationToken.IsCancellationRequested && await timer.WaitForNextTickAsync(serviceStopCancellationToken))
+        try
         {
-            if (_backgroundQueue.ConcurrentCount < _backgroundQueue.MaxConcurrentCount)
+            // WaitForNextTickAsync observes the stop token, so we don't need to re-check IsCancellationRequested.
+            while (await timer.WaitForNextTickAsync(serviceStopCancellationToken))
             {
-                // ExecuteAsync is a long-running while the background service is running, so we can't use default dependency injection behaviour.
-                // To prevent open resources and instances - scope services per run */
-                // Create scope, so we get request services
-                _backgroundQueue.Dequeue(serviceStopCancellationToken, _serviceScopeFactory);
+                if (_backgroundQueue.ConcurrentCount < _backgroundQueue.MaxConcurrentCount)
+                {
+                    // ExecuteAsync is long-running while the background service is running, so we can't use default dependency injection behaviour.
+                    // To prevent open resources and instances - scope services per run.
+                    _backgroundQueue.Dequeue(serviceStopCancellationToken, _serviceScopeFactory);
+                }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on graceful shutdown when the stop token is cancelled.
+        }
+        finally
+        {
+            // Don't abandon tasks that are still running - let them drain (bounded by the host's shutdown timeout)
+            // so their service scopes aren't disposed underneath them.
+            await _backgroundQueue.WhenAllInFlightComplete();
         }
     }
 }

--- a/DalSoft.Hosting.BackgroundQueue/DalSoft.Hosting.BackgroundQueue.csproj
+++ b/DalSoft.Hosting.BackgroundQueue/DalSoft.Hosting.BackgroundQueue.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.1</VersionPrefix>
-    <TargetFramework>net6.0</TargetFramework>
+    <VersionPrefix>2.1.0</VersionPrefix>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>DalSoft.Hosting.BackgroundQueue</AssemblyName>
     <PackageId>DalSoft.Hosting.BackgroundQueue</PackageId>
-    <Title>DalSoft.Hosting.BackgroundQueue - lightweight .NET Core replacement for HostingEnvironment.QueueBackgroundWorkItem</Title>
-    <Description>DalSoft.Hosting.BackgroundQueue is a very lightweight .NET Core replacement for HostingEnvironment.QueueBackgroundWorkItem using IHostedService</Description>
+    <Title>DalSoft.Hosting.BackgroundQueue - lightweight Hangfire alternative: background queue + dynamic cron scheduler</Title>
+    <Description>A very lightweight .NET background-jobs library: an in-memory background task queue (a replacement for HostingEnvironment.QueueBackgroundWorkItem) plus a dynamic cron scheduler you can add, reschedule and remove jobs on at runtime - no restart. Per-job DI scope, optional bring-your-own durable store. A focused, low-dependency alternative to Hangfire for in-memory, single-instance scheduling and queuing.</Description>
     <Copyright>DalSoft Ltd</Copyright>
-    <PackageTags>asp.net core webbackgrounder environment.queuebackgroundworkitem IHostedService IHost IWebHost background</PackageTags>
+    <PackageTags>asp.net core background queue scheduler cron recurring jobs hangfire IHostedService BackgroundService environment.queuebackgroundworkitem webbackgrounder</PackageTags>
     <Owners>DalSoft</Owners>
     <Authors>DalSoft</Authors>
-    <PackageReleaseNotes>Reduced millisecondsToWaitBeforePickingUpTask to 10 milliseconds. Better handling if CreateAsyncScope ever fails.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added a dynamic cron scheduler (AddBackgroundJobs / IJobScheduler) with add, reschedule and remove at runtime, per-job DI scope, and a pluggable IScheduleStore for durable schedules. The scheduler ticks in-memory and never polls the store. Fully backwards compatible: the existing queue API is unchanged. Also hardened graceful shutdown so in-flight queue tasks drain instead of being abandoned. Now multi-targets net6.0 and net8.0.</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -22,12 +22,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <None Include="Assets\icon.png" Pack="true" PackagePath="\"/>
     <None Include="Assets\LICENSE" Pack="true" PackagePath="\"/>
     <None Include="../README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="DalSoft.Hosting.BackgroundQueue.Test" />
   </ItemGroup>

--- a/DalSoft.Hosting.BackgroundQueue/Extensions/DependencyInjection/Extensions.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Extensions/DependencyInjection/Extensions.cs
@@ -8,7 +8,7 @@ namespace DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection
         public static void AddBackgroundQueue(this IServiceCollection services, Action<Exception, AsyncServiceScope> onException, int maxConcurrentCount = 1, int millisecondsToWaitBeforePickingUpTask = 10)
         {
             services.AddSingleton(new BackgroundQueue(onException, maxConcurrentCount, millisecondsToWaitBeforePickingUpTask));
-            services.AddSingleton<IBackgroundQueue>(provider => provider.GetService<BackgroundQueue>());
+            services.AddSingleton<IBackgroundQueue>(provider => provider.GetRequiredService<BackgroundQueue>());
             services.AddHostedService<BackgroundQueueService>();
         }
     }
@@ -23,7 +23,7 @@ namespace DalSoft.Hosting.BackgroundQueue.DependencyInjection
         {
             // keep usage backwards compatible with < DalSoft.Hosting.BackgroundQueue v2.0.0
             services.AddSingleton(new BackgroundQueue((exception, _) => onException(exception), maxConcurrentCount, millisecondsToWaitBeforePickingUpTask));
-            services.AddSingleton<IBackgroundQueue>(provider => provider.GetService<BackgroundQueue>());
+            services.AddSingleton<IBackgroundQueue>(provider => provider.GetRequiredService<BackgroundQueue>());
             services.AddHostedService<BackgroundQueueService>();
         }
     }

--- a/DalSoft.Hosting.BackgroundQueue/PublicAPI.Shipped.txt
+++ b/DalSoft.Hosting.BackgroundQueue/PublicAPI.Shipped.txt
@@ -1,0 +1,23 @@
+#nullable enable
+DalSoft.Hosting.BackgroundQueue.BackgroundQueue
+DalSoft.Hosting.BackgroundQueue.BackgroundQueue.ConcurrentCount.get -> int
+DalSoft.Hosting.BackgroundQueue.BackgroundQueue.Count.get -> int
+DalSoft.Hosting.BackgroundQueue.BackgroundQueue.MaxConcurrentCount.get -> int
+DalSoft.Hosting.BackgroundQueue.BackgroundQueue.MillisecondsToWaitBeforePickingUpTask.get -> int
+DalSoft.Hosting.BackgroundQueue.BackgroundQueueService
+DalSoft.Hosting.BackgroundQueue.DependencyInjection.Extensions
+DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection.Extensions
+DalSoft.Hosting.BackgroundQueue.IBackgroundQueue
+DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.ConcurrentCount.get -> int
+DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.Count.get -> int
+DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.MaxConcurrentCount.get -> int
+DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.MillisecondsToWaitBeforePickingUpTask.get -> int
+~DalSoft.Hosting.BackgroundQueue.BackgroundQueue.BackgroundQueue(System.Action<System.Exception, Microsoft.Extensions.DependencyInjection.AsyncServiceScope> onException, int maxConcurrentCount, int millisecondsToWaitBeforePickingUpTask) -> void
+~DalSoft.Hosting.BackgroundQueue.BackgroundQueue.Enqueue(System.Func<System.Threading.CancellationToken, Microsoft.Extensions.DependencyInjection.AsyncServiceScope, System.Threading.Tasks.Task> task) -> void
+~DalSoft.Hosting.BackgroundQueue.BackgroundQueue.Enqueue(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> task) -> void
+~DalSoft.Hosting.BackgroundQueue.BackgroundQueueService.BackgroundQueueService(DalSoft.Hosting.BackgroundQueue.BackgroundQueue backgroundQueue, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) -> void
+~DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.Enqueue(System.Func<System.Threading.CancellationToken, Microsoft.Extensions.DependencyInjection.AsyncServiceScope, System.Threading.Tasks.Task> task) -> void
+~DalSoft.Hosting.BackgroundQueue.IBackgroundQueue.Enqueue(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> task) -> void
+~override DalSoft.Hosting.BackgroundQueue.BackgroundQueueService.ExecuteAsync(System.Threading.CancellationToken serviceStopCancellationToken) -> System.Threading.Tasks.Task
+~static DalSoft.Hosting.BackgroundQueue.DependencyInjection.Extensions.AddBackgroundQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<System.Exception> onException, int maxConcurrentCount = 1, int millisecondsToWaitBeforePickingUpTask = 10) -> void
+~static DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection.Extensions.AddBackgroundQueue(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<System.Exception, Microsoft.Extensions.DependencyInjection.AsyncServiceScope> onException, int maxConcurrentCount = 1, int millisecondsToWaitBeforePickingUpTask = 10) -> void

--- a/DalSoft.Hosting.BackgroundQueue/PublicAPI.Unshipped.txt
+++ b/DalSoft.Hosting.BackgroundQueue/PublicAPI.Unshipped.txt
@@ -1,0 +1,56 @@
+#nullable enable
+DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection.BackgroundJobsServiceCollectionExtensions
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions.BackgroundJobsOptions() -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions.OnException.get -> System.Action<System.Exception!, string!>?
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions.OnException.set -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions.TickInterval.get -> System.TimeSpan
+DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions.TickInterval.set -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.IInvocable
+DalSoft.Hosting.BackgroundQueue.Scheduling.IInvocable.Invoke() -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IInvocableWithPayload
+DalSoft.Hosting.BackgroundQueue.Scheduling.IInvocableWithPayload.Payload.get -> string?
+DalSoft.Hosting.BackgroundQueue.Scheduling.IInvocableWithPayload.Payload.set -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.Exists(string! key) -> bool
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.List() -> System.Collections.Generic.IReadOnlyCollection<DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo!>!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.ReloadFromStoreAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.RemoveAsync(string! key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.RescheduleAsync(string! key, string! cronExpression, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.ScheduleAsync(string! key, string! cronExpression, System.Type! invocableType, string? payload = null, string? timeZoneId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IJobScheduler.ScheduleAsync<TInvocable>(string! key, string! cronExpression, string? payload = null, string? timeZoneId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IScheduleStore
+DalSoft.Hosting.BackgroundQueue.Scheduling.IScheduleStore.LoadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition!>!>!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IScheduleStore.RemoveAsync(string! key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.IScheduleStore.UpsertAsync(DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition! definition, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ISystemClock
+DalSoft.Hosting.BackgroundQueue.Scheduling.ISystemClock.UtcNow.get -> System.DateTime
+DalSoft.Hosting.BackgroundQueue.Scheduling.InMemoryScheduleStore
+DalSoft.Hosting.BackgroundQueue.Scheduling.InMemoryScheduleStore.InMemoryScheduleStore() -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.InMemoryScheduleStore.LoadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition!>!>!
+DalSoft.Hosting.BackgroundQueue.Scheduling.InMemoryScheduleStore.RemoveAsync(string! key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.InMemoryScheduleStore.UpsertAsync(DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition! definition, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.CronExpression.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.CronExpression.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.InvocableType.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.InvocableType.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.Key.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.Key.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.Payload.get -> string?
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.Payload.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.TimeZoneId.get -> string?
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduleDefinition.TimeZoneId.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.CronExpression.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.CronExpression.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.InvocableType.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.InvocableType.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.IsRunning.get -> bool
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.IsRunning.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.Key.get -> string!
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.Key.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.NextRunUtc.get -> System.DateTime
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.NextRunUtc.init -> void
+DalSoft.Hosting.BackgroundQueue.Scheduling.ScheduledJobInfo.ScheduledJobInfo(string! Key, string! CronExpression, string! InvocableType, System.DateTime NextRunUtc, bool IsRunning) -> void
+static DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection.BackgroundJobsServiceCollectionExtensions.AddBackgroundJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<DalSoft.Hosting.BackgroundQueue.Scheduling.BackgroundJobsOptions!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/BackgroundJobsOptions.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/BackgroundJobsOptions.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>Options for the cron scheduler, configured via AddBackgroundJobs.</summary>
+public sealed class BackgroundJobsOptions
+{
+    /// <summary>
+    /// How often the scheduler checks the in-memory schedule for due jobs. Defaults to one second.
+    /// This is an in-memory check only - it never touches the <see cref="IScheduleStore"/> / database.
+    /// Keep it at or below the smallest precision you schedule (e.g. 1s if you use seconds-precision cron).
+    /// </summary>
+    public TimeSpan TickInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Called when a scheduled invocable throws. The string is the job key. If null, exceptions from
+    /// invocables are swallowed (other jobs continue), mirroring the queue's per-task isolation.
+    /// </summary>
+    public Action<Exception, string>? OnException { get; set; }
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/BackgroundJobsServiceCollectionExtensions.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/BackgroundJobsServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+// Same namespace as AddBackgroundQueue so both are discoverable from one using directive.
+namespace DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection
+{
+    public static class BackgroundJobsServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the dynamic cron scheduler. Resolve <see cref="IJobScheduler"/> to add, reschedule or remove
+        /// jobs at runtime. Register your own <see cref="IScheduleStore"/> before or after this call to make
+        /// schedules durable; otherwise an in-memory store is used.
+        /// </summary>
+        /// <remarks>
+        /// Additive and independent of AddBackgroundQueue - calling this does not change queue behaviour, and
+        /// the queue can be used without the scheduler. A common pattern is a scheduled <see cref="IInvocable"/>
+        /// that injects <see cref="IBackgroundQueue"/> and enqueues the heavy work onto the throttled queue.
+        /// </remarks>
+        public static IServiceCollection AddBackgroundJobs(this IServiceCollection services, Action<BackgroundJobsOptions>? configure = null)
+        {
+            var options = new BackgroundJobsOptions();
+            configure?.Invoke(options);
+
+            services.AddSingleton(options);
+            services.TryAddSingleton<ISystemClock, SystemClock>();
+            services.TryAddSingleton<IScheduleStore, InMemoryScheduleStore>();
+            services.AddSingleton<JobScheduler>();
+            services.AddSingleton<IJobScheduler>(provider => provider.GetRequiredService<JobScheduler>());
+            services.AddHostedService<SchedulerHostedService>();
+
+            return services;
+        }
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/IInvocable.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/IInvocable.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Threading.Tasks;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// A unit of scheduled work. Implementations are resolved from the DI container (a fresh scope per run),
+/// so they can take scoped dependencies (DbContext, repositories, <see cref="IBackgroundQueue"/>, etc.)
+/// via constructor injection.
+/// </summary>
+public interface IInvocable
+{
+    Task Invoke();
+}
+
+/// <summary>
+/// Optional companion to <see cref="IInvocable"/>. If a scheduled invocable also implements this,
+/// the scheduler sets <see cref="Payload"/> from the persisted schedule before calling
+/// <see cref="IInvocable.Invoke"/>. Keeps schedules durable: parameters travel as data, not as a closure.
+/// </summary>
+public interface IInvocableWithPayload
+{
+    string? Payload { get; set; }
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/IJobScheduler.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/IJobScheduler.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// Add, change and remove cron schedules at runtime - no restart required. Mutations write through to the
+/// configured <see cref="IScheduleStore"/>; the running schedule lives in memory and is what the tick loop reads.
+/// </summary>
+public interface IJobScheduler
+{
+    /// <summary>Schedules <typeparamref name="TInvocable"/> under <paramref name="key"/>. Replaces any existing job with the same key.</summary>
+    Task ScheduleAsync<TInvocable>(string key, string cronExpression, string? payload = null, string? timeZoneId = null, CancellationToken cancellationToken = default)
+        where TInvocable : IInvocable;
+
+    /// <summary>Schedules <paramref name="invocableType"/> (must implement <see cref="IInvocable"/>) under <paramref name="key"/>.</summary>
+    Task ScheduleAsync(string key, string cronExpression, Type invocableType, string? payload = null, string? timeZoneId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Changes the cron expression of an existing job. Takes effect on the next tick.</summary>
+    Task RescheduleAsync(string key, string cronExpression, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a job. Returns false if no job with that key existed. Takes effect on the next tick.</summary>
+    Task<bool> RemoveAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>True if a job with the given key is currently scheduled (in-memory; no store access).</summary>
+    bool Exists(string key);
+
+    /// <summary>A snapshot of the currently scheduled jobs (in-memory; no store access).</summary>
+    IReadOnlyCollection<ScheduledJobInfo> List();
+
+    /// <summary>
+    /// Re-reads every schedule from the <see cref="IScheduleStore"/> and replaces the in-memory schedule.
+    /// This is the only way to pick up schedule changes made directly in the store by another process.
+    /// Call it sparingly (e.g. from inside a scheduled "sync" job) so an idle database is never polled.
+    /// </summary>
+    Task ReloadFromStoreAsync(CancellationToken cancellationToken = default);
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/IScheduleStore.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/IScheduleStore.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// Durable persistence for schedules - implement this to back schedules with your own store
+/// (EF Core, Dapper, table storage, etc.). The default registration is an in-memory store.
+/// </summary>
+/// <remarks>
+/// IMPORTANT: this is only touched at three points - never on the scheduler's tick:
+/// <list type="number">
+/// <item>once on startup, via <see cref="LoadAsync"/>;</item>
+/// <item>when a schedule is added/changed/removed, via <see cref="UpsertAsync"/> / <see cref="RemoveAsync"/>;</item>
+/// <item>when you explicitly call <see cref="IJobScheduler.ReloadFromStoreAsync"/> (ideally from inside a scheduled job).</item>
+/// </list>
+/// The per-tick scheduling loop runs entirely against the in-memory schedule, so a serverless/pay-per-use
+/// database is never polled while idle.
+/// </remarks>
+public interface IScheduleStore
+{
+    /// <summary>Loads all persisted schedules. Called once at startup (and on an explicit reload).</summary>
+    Task<IReadOnlyCollection<ScheduleDefinition>> LoadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Inserts or updates a schedule (write-through when a schedule is added or rescheduled).</summary>
+    Task UpsertAsync(ScheduleDefinition definition, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a schedule by key (write-through when a schedule is removed).</summary>
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/ISystemClock.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/ISystemClock.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>Abstracts the current time so the scheduler is deterministically testable.</summary>
+public interface ISystemClock
+{
+    DateTime UtcNow { get; }
+}
+
+internal sealed class SystemClock : ISystemClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/InMemoryScheduleStore.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/InMemoryScheduleStore.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// Default <see cref="IScheduleStore"/>. Keeps schedules in process memory only, so dynamic changes are
+/// lost on restart. Swap in your own <see cref="IScheduleStore"/> to make schedules durable.
+/// </summary>
+public sealed class InMemoryScheduleStore : IScheduleStore
+{
+    private readonly ConcurrentDictionary<string, ScheduleDefinition> _store = new();
+
+    public Task<IReadOnlyCollection<ScheduleDefinition>> LoadAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyCollection<ScheduleDefinition>>(_store.Values.ToArray());
+
+    public Task UpsertAsync(ScheduleDefinition definition, CancellationToken cancellationToken = default)
+    {
+        _store[definition.Key] = definition;
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        _store.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/JobScheduler.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/JobScheduler.cs
@@ -1,0 +1,109 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// In-memory cron scheduler with durable write-through. The <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// of jobs is the runtime source of truth; the tick loop only ever reads it. The <see cref="IScheduleStore"/>
+/// is touched on load, on mutation, and on an explicit reload - never on the tick.
+/// </summary>
+internal sealed class JobScheduler : IJobScheduler
+{
+    private readonly ConcurrentDictionary<string, ScheduledJob> _jobs = new();
+    private readonly IScheduleStore _store;
+    private readonly ISystemClock _clock;
+
+    public JobScheduler(IScheduleStore store, ISystemClock clock)
+    {
+        _store = store;
+        _clock = clock;
+    }
+
+    public Task ScheduleAsync<TInvocable>(string key, string cronExpression, string? payload = null, string? timeZoneId = null, CancellationToken cancellationToken = default)
+        where TInvocable : IInvocable
+        => ScheduleAsync(key, cronExpression, typeof(TInvocable), payload, timeZoneId, cancellationToken);
+
+    public async Task ScheduleAsync(string key, string cronExpression, Type invocableType, string? payload = null, string? timeZoneId = null, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key is required.", nameof(key));
+        if (invocableType is null) throw new ArgumentNullException(nameof(invocableType));
+
+        var definition = new ScheduleDefinition
+        {
+            Key = key,
+            CronExpression = cronExpression,
+            InvocableType = TypeName(invocableType),
+            Payload = payload,
+            TimeZoneId = timeZoneId
+        };
+
+        // Build first so an invalid cron / type / time zone throws before we persist anything.
+        var job = ScheduledJob.Create(definition, _clock.UtcNow);
+
+        // Store first, then memory: a crash between the two is recoverable on the next load.
+        await _store.UpsertAsync(definition, cancellationToken).ConfigureAwait(false);
+        _jobs[key] = job;
+    }
+
+    public async Task RescheduleAsync(string key, string cronExpression, CancellationToken cancellationToken = default)
+    {
+        if (!_jobs.TryGetValue(key, out var existing))
+        {
+            throw new KeyNotFoundException($"No scheduled job with key '{key}'.");
+        }
+
+        var definition = existing.Definition with { CronExpression = cronExpression };
+        var job = ScheduledJob.Create(definition, _clock.UtcNow);
+
+        await _store.UpsertAsync(definition, cancellationToken).ConfigureAwait(false);
+        _jobs[key] = job;
+    }
+
+    public async Task<bool> RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        await _store.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+        return _jobs.TryRemove(key, out _);
+    }
+
+    public bool Exists(string key) => _jobs.ContainsKey(key);
+
+    public IReadOnlyCollection<ScheduledJobInfo> List() => _jobs.Values.Select(job => job.ToInfo()).ToArray();
+
+    public async Task ReloadFromStoreAsync(CancellationToken cancellationToken = default)
+    {
+        var definitions = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        var now = _clock.UtcNow;
+        var keptKeys = new HashSet<string>();
+
+        foreach (var definition in definitions)
+        {
+            keptKeys.Add(definition.Key);
+
+            // Preserve a live job whose schedule is unchanged so we don't reset its NextRunUtc or running flag.
+            if (_jobs.TryGetValue(definition.Key, out var existing) && existing.Definition == definition)
+            {
+                continue;
+            }
+
+            _jobs[definition.Key] = ScheduledJob.Create(definition, now);
+        }
+
+        // Drop jobs that no longer exist in the store.
+        foreach (var key in _jobs.Keys.Where(key => !keptKeys.Contains(key)).ToArray())
+        {
+            _jobs.TryRemove(key, out _);
+        }
+    }
+
+    // ----- consumed by SchedulerHostedService (same assembly); all in-memory, never touches the store -----
+
+    internal IEnumerable<ScheduledJob> DueJobs(DateTime utcNow) => _jobs.Values.Where(job => job.IsDue(utcNow));
+
+    private static string TypeName(Type type) => $"{type.FullName}, {type.Assembly.GetName().Name}";
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/ScheduleDefinition.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/ScheduleDefinition.cs
@@ -1,0 +1,33 @@
+#nullable enable
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// The durable representation of a scheduled job - a flat, serializable record an <see cref="IScheduleStore"/>
+/// can persist (EF, Dapper, table storage, etc.). The job is identified by <see cref="InvocableType"/> rather
+/// than a delegate so it can be rebuilt after a restart.
+/// </summary>
+public sealed record ScheduleDefinition
+{
+    /// <summary>Stable, unique identity used to reschedule or remove the job.</summary>
+    public string Key { get; init; } = default!;
+
+    /// <summary>A standard (5-field) or seconds-precision (6-field) cron expression.</summary>
+    public string CronExpression { get; init; } = default!;
+
+    /// <summary>The <see cref="IInvocable"/> type to run, as "Namespace.Type, AssemblyName" (version independent).</summary>
+    public string InvocableType { get; init; } = default!;
+
+    /// <summary>Optional data handed to the invocable if it implements <see cref="IInvocableWithPayload"/>.</summary>
+    public string? Payload { get; init; }
+
+    /// <summary>Optional time zone id the cron expression is evaluated in. Null means UTC.</summary>
+    public string? TimeZoneId { get; init; }
+}
+
+/// <summary>A read-only snapshot of a live scheduled job, returned by <see cref="IJobScheduler.List"/>.</summary>
+public sealed record ScheduledJobInfo(
+    string Key,
+    string CronExpression,
+    string InvocableType,
+    System.DateTime NextRunUtc,
+    bool IsRunning);

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/ScheduledJob.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/ScheduledJob.cs
@@ -1,0 +1,85 @@
+#nullable enable
+using System;
+using System.Threading;
+using Cronos;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// The live, in-memory representation of a scheduled job. Created from a <see cref="ScheduleDefinition"/>
+/// with its cron expression and target type pre-parsed/resolved so the tick loop does no parsing or I/O.
+/// </summary>
+internal sealed class ScheduledJob
+{
+    /// <summary>Sentinel for a cron expression that will never fire again (e.g. a one-off date in the past).</summary>
+    public static readonly DateTime Never = DateTime.MaxValue;
+
+    private int _running;
+
+    private ScheduledJob(ScheduleDefinition definition, CronExpression cron, TimeZoneInfo timeZone, Type resolvedType)
+    {
+        Definition = definition;
+        Cron = cron;
+        TimeZone = timeZone;
+        ResolvedType = resolvedType;
+    }
+
+    public ScheduleDefinition Definition { get; }
+    public CronExpression Cron { get; }
+    public TimeZoneInfo TimeZone { get; }
+    public Type ResolvedType { get; }
+
+    public string Key => Definition.Key;
+    public string? Payload => Definition.Payload;
+
+    public DateTime NextRunUtc { get; private set; }
+
+    public bool IsRunning => Volatile.Read(ref _running) == 1;
+
+    /// <summary>Atomically claims the job for a run; returns false if it's already running (overlap prevention).</summary>
+    public bool TryBeginRun() => Interlocked.CompareExchange(ref _running, 1, 0) == 0;
+
+    public void EndRun() => Volatile.Write(ref _running, 0);
+
+    public bool IsDue(DateTime utcNow) => NextRunUtc <= utcNow;
+
+    /// <summary>Advances <see cref="NextRunUtc"/> to the next occurrence strictly after <paramref name="fromUtc"/>.</summary>
+    public void AdvanceNextRun(DateTime fromUtc)
+    {
+        var next = Cron.GetNextOccurrence(new DateTimeOffset(fromUtc, TimeSpan.Zero), TimeZone);
+        NextRunUtc = next?.UtcDateTime ?? Never;
+    }
+
+    public ScheduledJobInfo ToInfo() => new(Key, Definition.CronExpression, Definition.InvocableType, NextRunUtc, IsRunning);
+
+    /// <summary>
+    /// Builds a runnable job from a stored definition: parses the cron (5 or 6 field), resolves the time zone
+    /// and the <see cref="IInvocable"/> type, and computes the first <see cref="NextRunUtc"/> from now.
+    /// Throws on an invalid cron expression, unknown time zone, or a type that isn't an <see cref="IInvocable"/>.
+    /// </summary>
+    public static ScheduledJob Create(ScheduleDefinition definition, DateTime utcNow)
+    {
+        var cron = ParseCron(definition.CronExpression);
+        var timeZone = definition.TimeZoneId is null
+            ? TimeZoneInfo.Utc
+            : TimeZoneInfo.FindSystemTimeZoneById(definition.TimeZoneId);
+
+        var type = Type.GetType(definition.InvocableType, throwOnError: true)!;
+        if (!typeof(IInvocable).IsAssignableFrom(type))
+        {
+            throw new ArgumentException($"Type '{definition.InvocableType}' does not implement {nameof(IInvocable)}.", nameof(definition));
+        }
+
+        var job = new ScheduledJob(definition, cron, timeZone, type);
+        job.AdvanceNextRun(utcNow);
+        return job;
+    }
+
+    private static CronExpression ParseCron(string expression)
+    {
+        var fieldCount = expression.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+        return fieldCount == 6
+            ? CronExpression.Parse(expression, CronFormat.IncludeSeconds)
+            : CronExpression.Parse(expression);
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue/Scheduling/SchedulerHostedService.cs
+++ b/DalSoft.Hosting.BackgroundQueue/Scheduling/SchedulerHostedService.cs
@@ -1,0 +1,123 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+/// <summary>
+/// Drives the scheduler. Loads schedules from the store once at startup, then ticks against the in-memory
+/// schedule only - the store/database is never polled while idle. Due jobs run in their own DI scope.
+/// </summary>
+internal sealed class SchedulerHostedService : BackgroundService
+{
+    private readonly JobScheduler _scheduler;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ISystemClock _clock;
+    private readonly BackgroundJobsOptions _options;
+    private readonly ConcurrentDictionary<Task, byte> _inFlight = new();
+
+    public SchedulerHostedService(JobScheduler scheduler, IServiceScopeFactory serviceScopeFactory, ISystemClock clock, BackgroundJobsOptions options)
+    {
+        _scheduler = scheduler;
+        _serviceScopeFactory = serviceScopeFactory;
+        _clock = clock;
+        _options = options;
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        // The single startup read of the store - hydrates the in-memory schedule.
+        await _scheduler.ReloadFromStoreAsync(cancellationToken).ConfigureAwait(false);
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken serviceStopCancellationToken)
+    {
+        using PeriodicTimer timer = new(_options.TickInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(serviceStopCancellationToken))
+            {
+                RunDueJobs(serviceStopCancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on graceful shutdown.
+        }
+        finally
+        {
+            // Let running jobs drain (bounded by the host's shutdown timeout) rather than disposing their scopes underneath them.
+            await Task.WhenAll(_inFlight.Keys.ToArray()).ConfigureAwait(false);
+        }
+    }
+
+    private void RunDueJobs(CancellationToken serviceStopCancellationToken)
+    {
+        var now = _clock.UtcNow;
+
+        foreach (var job in _scheduler.DueJobs(now))
+        {
+            if (!job.TryBeginRun())
+            {
+                continue; // already running - prevent overlap
+            }
+
+            // Advance immediately so the next occurrence is based on schedule, not on how long this run takes.
+            job.AdvanceNextRun(now);
+
+            var task = RunJobAsync(job, serviceStopCancellationToken);
+            if (task.IsCompleted)
+            {
+                continue;
+            }
+
+            _inFlight[task] = 0;
+            _ = task.ContinueWith(
+                static (completed, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(completed, out _),
+                _inFlight,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+
+    private async Task RunJobAsync(ScheduledJob job, CancellationToken serviceStopCancellationToken)
+    {
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+
+            var invocable = (IInvocable)(scope.ServiceProvider.GetService(job.ResolvedType)
+                                         ?? ActivatorUtilities.CreateInstance(scope.ServiceProvider, job.ResolvedType));
+
+            if (job.Payload is not null && invocable is IInvocableWithPayload withPayload)
+            {
+                withPayload.Payload = job.Payload;
+            }
+
+            await invocable.Invoke().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            try
+            {
+                _options.OnException?.Invoke(exception, job.Key);
+            }
+            catch
+            {
+                // The user's handler threw; swallow so it doesn't become an unobserved task exception.
+            }
+        }
+        finally
+        {
+            job.EndRun();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 
 # DalSoft.Hosting.BackgroundQueue
 
-DalSoft.Hosting.BackgroundQueue is a very lightweight .NET Core replacement for [HostingEnvironment.QueueBackgroundWorkItem](https://www.hanselman.com/blog/HowToRunBackgroundTasksInASPNET.aspx) it has no extra dependencies!
+DalSoft.Hosting.BackgroundQueue is a very lightweight .NET background-jobs library - a focused, low-dependency alternative to Hangfire for in-memory, single-instance work. It gives you two things:
+
+* **A background task queue** - the original, a very lightweight replacement for [HostingEnvironment.QueueBackgroundWorkItem](https://www.hanselman.com/blog/HowToRunBackgroundTasksInASPNET.aspx).
+* **A dynamic cron scheduler** (since v2.1.0) - add, reschedule and remove cron jobs **at runtime, with no restart**, with an optional bring-your-own durable store.
+
+The two compose: schedule *when* with the scheduler, run *how* (throttled, scoped) on the queue.
 
 For those of you that haven't used HostingEnvironment.QueueBackgroundWorkItem it was a simple way in .NET 4.5.2 to safely run a background task on a webhost, for example, sending an email when a user registers. 
 
@@ -17,7 +22,7 @@ This package has over 345k downloads and is used in many production environments
 
 ## Supported Platforms
 
-v2.0.0 DalSoft.Hosting.BackgroundQueue uses [BackgroundService](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-8.0&tabs=visual-studio), and works with .NET 6.0 and above.
+v2.0.0+ DalSoft.Hosting.BackgroundQueue uses [BackgroundService](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-8.0&tabs=visual-studio), and works with .NET 6.0 and above (the package multi-targets net6.0 and net8.0).
 
 v1.1.1 DalSoft.Hosting.BackgroundQueue uses [IHostedService](https://blogs.msdn.microsoft.com/cesardelatorre/2017/11/18/implementing-background-tasks-in-microservices-with-ihostedservice-and-the-backgroundservice-class-net-core-2-x/) and works with any .NET Core 2.0 or higher IWebHost i.e. a server that supports ASP.NET Core. v.1.1.1 doesn't support DI (you don't get the serviceScope parameter). 
 
@@ -42,7 +47,7 @@ builder.Services.AddBackgroundQueue
 > This setups DalSoft.Hosting.BackgroundQueue using .NET Core's DI container. If you're using a different DI container, you need to register BackgroundQueue, IBackgroundQueue and BackgroundQueueService as singletons.
 
 **onException (required)** <br />
-You are running tasks in the background on a different thread you need to know when an exception occurred. This is done using the ```Action<Exception, IServiceScopeFactory>``` parameter passed to onException. onException is called any time a Task throws an exception. 
+You are running tasks in the background on a different thread you need to know when an exception occurred. This is done using the ```Action<Exception, AsyncServiceScope>``` parameter passed to onException. onException is called any time a Task throws an exception. 
 
 **maxConcurrentCount (optional)** <br />
 maxConcurrentCount is the number of Tasks allowed to run in the background concurrently. maxConcurrentCount defaults to 1. Setting maxConcurrentCount lower than 1 throws an exception.
@@ -52,7 +57,7 @@ millisecondsToWaitBeforePickingUpTask is the delay before a background Task is a
 Setting millisecondsToWaitBeforePickingUpTask lower than 10 throws an exception. In most cases you shouldn't need to change this setting it's useful if you have to ['warm up'](https://payodatechnologyinc.medium.com/cache-warming-and-its-importance-5724148ab5f5) or need more throttling before hitting the maxConcurrentCount.
 
 > As you would expect exceptions only affect the Task causing the exception, all other Tasks are processed as normal.
-> You can get your services from the IServiceScopeFactory parameter i.e. `serviceScope.ServiceProvider.GetRequiredService<ILogger<Program>>()`.
+> You can get your services from the AsyncServiceScope parameter i.e. `serviceScope.ServiceProvider.GetRequiredService<ILogger<Program>>()`.
 
 ## Queuing a Background Task
 
@@ -94,6 +99,68 @@ app.MapPost("/", (IBackgroundQueue backgroundQueue) =>
 
 A fully working ASP.NET example targeting net8.0 can be found [here](https://github.com/DalSoft/DalSoft.Hosting.BackgroundQueue/tree/master/DalSoft.Hosting.BackgroundQueue.Examples.WebApi). 
 
+## Scheduling cron jobs (since v2.1.0)
+
+The scheduler lets you run jobs on a cron schedule and - unlike most schedulers - **add, reschedule and remove those jobs at runtime without restarting your app**. It's completely separate from the queue: adding it changes nothing about existing queue usage.
+
+Register it (in addition to, or instead of, `AddBackgroundQueue`):
+```cs
+builder.Services.AddBackgroundJobs();
+```
+
+Write your job as an `IInvocable`. It's resolved from DI in a fresh scope per run, so it can take scoped dependencies (a `DbContext`, repositories, or `IBackgroundQueue`) via the constructor:
+```cs
+public class SendDigestEmails : IInvocable
+{
+    private readonly IBackgroundQueue _queue;
+    public SendDigestEmails(IBackgroundQueue queue) => _queue = queue;
+
+    public Task Invoke()
+    {
+        // Schedule decides WHEN; hand the heavy work to the throttled queue to decide HOW it runs.
+        _queue.Enqueue(async (ct, scope) =>
+        {
+            var mailer = scope.ServiceProvider.GetRequiredService<IMailer>();
+            await mailer.SendDigestsAsync(ct);
+        });
+        return Task.CompletedTask;
+    }
+}
+```
+
+Add, change and remove schedules at runtime by resolving `IJobScheduler` anywhere (a controller, a minimal API, another job):
+```cs
+app.MapPost("/schedules/digest", async (IJobScheduler scheduler) =>
+{
+    await scheduler.ScheduleAsync<SendDigestEmails>("daily-digest", "0 8 * * *"); // every day at 08:00 (UTC)
+});
+
+app.MapPut("/schedules/digest", async (IJobScheduler scheduler, string cron) =>
+{
+    await scheduler.RescheduleAsync("daily-digest", cron); // takes effect on the next tick - no restart
+});
+
+app.MapDelete("/schedules/digest", (IJobScheduler scheduler) => scheduler.RemoveAsync("daily-digest"));
+```
+
+* Cron is **standard 5-field** (`m h dom mon dow`) or **6-field with seconds** (`s m h dom mon dow`), parsed by [Cronos](https://github.com/HangfireIO/Cronos).
+* Pass a `timeZoneId` to evaluate the expression in a specific time zone (defaults to UTC).
+* Optional `payload` is handed to jobs that implement `IInvocableWithPayload` - keeps schedules durable by passing parameters as data rather than a captured closure.
+
+### Durable schedules (bring your own store)
+
+By default schedules live in memory and are lost on restart. Implement `IScheduleStore` to persist them (EF Core, Dapper, table storage, …) and register it before/after `AddBackgroundJobs`:
+```cs
+builder.Services.AddSingleton<IScheduleStore, MySqlScheduleStore>();
+builder.Services.AddBackgroundJobs();
+```
+
+**The scheduler never polls your database.** The store is read once at startup, written through only when a schedule is added/changed/removed, and otherwise the per-second tick runs entirely against the in-memory schedule. This is deliberate so a pay-per-use / serverless database (e.g. serverless Azure SQL) is never hit while the app is idle. If another process changes schedules directly in the store, call `IJobScheduler.ReloadFromStoreAsync()` to pick them up - ideally from inside a scheduled "sync" job, so even that read happens on your terms.
+
+### How this compares to Hangfire
+
+This is a *lightweight* alternative, not a replacement for everything Hangfire does. Reach for it when you want in-memory, single-instance scheduling/queuing with minimal dependencies and runtime-editable schedules. Hangfire is the better choice when you need built-in durable storage, automatic retries, a dashboard, or distributed processing across many servers - none of which this library provides out of the box (persistence is bring-your-own, and there's no retry/dashboard/clustering).
+
 ## FAQ
 
 ### I'm getting a System.ObjectDisposedException
@@ -106,6 +173,9 @@ You're getting your service from your controller instead of Enqueue (make your c
 DalSoft.Hosting.BackgroundQueue uses a [ConcurrentQueue](https://msdn.microsoft.com/en-us/library/dd267265(v=vs.110).aspx) and [interlocked operations](https://docs.microsoft.com/en-us/dotnet/standard/threading/interlocked-operations) so is completely thread safe, watch out for [Access to Modified Closure](https://weblogs.asp.net/fbouma/linq-beware-of-the-access-to-modified-closure-demon) issues.
 
 ### Brief History
+
+ **Update June 2026**
+ Version 2.1.0 adds a dynamic cron scheduler (`AddBackgroundJobs` / `IJobScheduler`) with add/reschedule/remove at runtime, per-job DI scope, and a pluggable `IScheduleStore` for durable schedules that never polls the database. The queue's graceful shutdown was also hardened so in-flight tasks drain instead of being abandoned. Fully backwards compatible - the existing queue API is unchanged - and now multi-targets net6.0 and net8.0.
 
  **Update September 2024** 
  Version 2.0 is here with full DI support, and support for minimal APIs. Version 2.0 API is fully backwards compatible with versions 1.x.x.


### PR DESCRIPTION
Adds a dynamic cron scheduler (v2.1.0) alongside the existing background queue, plus queue shutdown hardening. Fully additive - the v2.0.x queue API is unchanged. AddBackgroundJobs / IJobScheduler: add, reschedule and remove cron jobs at runtime; per-job DI scope; pluggable IScheduleStore that is never polled on the tick. Multi-targets net6.0 and net8.0; public API guarded by analyzers.