### PR TITLE
Example: EF Core IScheduleStore + runtime scheduling endpoints

### DIFF
--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/DalSoft.Hosting.BackgroundQueue.Test.WebApi.http
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/DalSoft.Hosting.BackgroundQueue.Test.WebApi.http
@@ -1,6 +1,25 @@
 @DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress = http://localhost:5184
 
-GET {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/weatherforecast/
+### Queue 20 background tasks
+POST {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/backgroundtasks
+
+### Get queue counts (Count / ConcurrentCount)
+GET {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/backgroundtasks
 Accept: application/json
+
+### --- Scheduler ---
+
+### List the currently scheduled jobs (in-memory snapshot, no DB hit)
+GET {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/schedules
+Accept: application/json
+
+### Add a schedule: add a random Person every 10 seconds (6-field cron, spaces URL-encoded)
+POST {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/schedules/add-person?cron=*/10%20*%20*%20*%20*%20*
+
+### Reschedule to every 30 seconds - takes effect on the next tick, no restart
+PUT {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/schedules/add-person?cron=*/30%20*%20*%20*%20*%20*
+
+### Remove the schedule - takes effect on the next tick, no restart
+DELETE {{DalSoft.Hosting.BackgroundQueue.Test.WebApi_HostAddress}}/schedules/add-person
 
 ###

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Endpoints/SchedulingEndpoints.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Endpoints/SchedulingEndpoints.cs
@@ -1,0 +1,43 @@
+using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Jobs;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Endpoints;
+
+public static class SchedulingEndpoints
+{
+    public static void MapSchedulingEndpoints(this WebApplication app)
+    {
+        // List the currently scheduled jobs (in-memory snapshot, no database access).
+        app.MapGet("/schedules", (IJobScheduler scheduler) => scheduler.List())
+            .WithName("List schedules")
+            .WithOpenApi();
+
+        // Add a schedule at runtime. e.g. cron = "*/10 * * * * *" (every 10 seconds, 6-field) or "0 8 * * *" (08:00 daily).
+        // The schedule is written through to the EF Core store, so it survives a restart.
+        app.MapPost("/schedules/{key}", async (string key, string cron, IJobScheduler scheduler) =>
+        {
+            await scheduler.ScheduleAsync<AddRandomPersonJob>(key, cron);
+            return Results.Ok(new { key, cron });
+        })
+        .WithName("Add or replace a schedule")
+        .WithOpenApi();
+
+        // Change an existing schedule's cron - takes effect on the next tick, no restart.
+        app.MapPut("/schedules/{key}", async (string key, string cron, IJobScheduler scheduler) =>
+        {
+            await scheduler.RescheduleAsync(key, cron);
+            return Results.Ok(new { key, cron });
+        })
+        .WithName("Reschedule")
+        .WithOpenApi();
+
+        // Remove a schedule - takes effect on the next tick, no restart.
+        app.MapDelete("/schedules/{key}", async (string key, IJobScheduler scheduler) =>
+        {
+            var removed = await scheduler.RemoveAsync(key);
+            return removed ? Results.Ok() : Results.NotFound();
+        })
+        .WithName("Remove a schedule")
+        .WithOpenApi();
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Extensions/HostExtensions.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Extensions/HostExtensions.cs
@@ -1,4 +1,6 @@
 using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Data;
+using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Scheduling;
+using Microsoft.EntityFrameworkCore;
 
 namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Extensions;
 
@@ -12,7 +14,10 @@ public static class HostExtensions
         {
             var context = services.GetRequiredService<PersonDbContext>();
             context.Database.EnsureCreated();
-                
+
+            // The schedule store uses its own database (see ScheduleStoreDbContext), created independently.
+            using var scheduleContext = services.GetRequiredService<IDbContextFactory<ScheduleStoreDbContext>>().CreateDbContext();
+            scheduleContext.Database.EnsureCreated();
         }
         catch (Exception ex)
         {

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Jobs/AddRandomPersonJob.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Jobs/AddRandomPersonJob.cs
@@ -1,0 +1,29 @@
+using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Data;
+using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Data.Entities;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+
+namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Jobs;
+
+/// <summary>
+/// A scheduled job. It's resolved from DI per run, so it can take dependencies via the constructor -
+/// here <see cref="IBackgroundQueue"/>. The scheduler decides WHEN this runs; the actual work is handed to
+/// the throttled queue, which decides HOW it runs (its own scope, concurrency limit, exception handling).
+/// </summary>
+public sealed class AddRandomPersonJob(IBackgroundQueue backgroundQueue) : IInvocable
+{
+    public Task Invoke()
+    {
+        backgroundQueue.Enqueue(async (cancellationToken, serviceScope) =>
+        {
+            var dbContext = serviceScope.ServiceProvider.GetRequiredService<PersonDbContext>();
+            await dbContext.People.AddAsync(new Person
+            {
+                FirstName = $"Scheduled {Guid.NewGuid()}",
+                LastName = "Person"
+            }, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Program.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Program.cs
@@ -1,7 +1,9 @@
 using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Data;
 using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Endpoints;
 using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Extensions;
+using DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Scheduling;
 using DalSoft.Hosting.BackgroundQueue.Extensions.DependencyInjection;
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -14,13 +16,20 @@ builder.Services.AddDbContext<PersonDbContext>(options =>
 
 builder.Services.AddBackgroundQueue
 (
-    onException: (exception, serviceScope) => 
-    { 
+    onException: (exception, serviceScope) =>
+    {
         serviceScope.ServiceProvider.GetRequiredService<ILogger<Program>>()
-        .Log(LogLevel.Error, exception, exception.Message); 
-    }, 
+        .Log(LogLevel.Error, exception, exception.Message);
+    },
     maxConcurrentCount: 10
 );
+
+// Durable cron scheduler. Register the EF Core store BEFORE AddBackgroundJobs so it's used instead of the
+// in-memory default. AddDbContextFactory keeps it singleton-safe (the store is resolved as a singleton).
+builder.Services.AddDbContextFactory<ScheduleStoreDbContext>(options =>
+    options.UseSqlServer(configuration.GetConnectionString(nameof(ScheduleStoreDbContext))));
+builder.Services.AddSingleton<IScheduleStore, EfCoreScheduleStore>();
+builder.Services.AddBackgroundJobs();
 
 var app = builder.Build();
 
@@ -35,6 +44,7 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.MapWeatherEndpoints();
+app.MapSchedulingEndpoints();
 
 app.Run();
 

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/EfCoreScheduleStore.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/EfCoreScheduleStore.cs
@@ -1,0 +1,71 @@
+using DalSoft.Hosting.BackgroundQueue.Scheduling;
+using Microsoft.EntityFrameworkCore;
+
+namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Scheduling;
+
+/// <summary>
+/// A durable <see cref="IScheduleStore"/> backed by EF Core / SQL Server. Drop-in: register it before
+/// AddBackgroundJobs and your schedules survive restarts.
+///
+/// Note it takes an <see cref="IDbContextFactory{TContext}"/>, not a DbContext. The scheduler resolves the
+/// store as a singleton, and a singleton must not capture a scoped DbContext - the factory hands us a short
+/// lived context per call instead. This store is only hit on startup load and on add/change/remove, never on
+/// the scheduler's tick, so an idle (e.g. serverless) database is never polled.
+/// </summary>
+public sealed class EfCoreScheduleStore(IDbContextFactory<ScheduleStoreDbContext> contextFactory) : IScheduleStore
+{
+    public async Task<IReadOnlyCollection<ScheduleDefinition>> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var rows = await db.Schedules.AsNoTracking().ToListAsync(cancellationToken);
+
+        return rows.Select(row => new ScheduleDefinition
+        {
+            Key = row.Key,
+            CronExpression = row.CronExpression,
+            InvocableType = row.InvocableType,
+            Payload = row.Payload,
+            TimeZoneId = row.TimeZoneId
+        }).ToArray();
+    }
+
+    public async Task UpsertAsync(ScheduleDefinition definition, CancellationToken cancellationToken = default)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var row = await db.Schedules.FindAsync([definition.Key], cancellationToken);
+        if (row is null)
+        {
+            db.Schedules.Add(new ScheduleRecord
+            {
+                Key = definition.Key,
+                CronExpression = definition.CronExpression,
+                InvocableType = definition.InvocableType,
+                Payload = definition.Payload,
+                TimeZoneId = definition.TimeZoneId
+            });
+        }
+        else
+        {
+            row.CronExpression = definition.CronExpression;
+            row.InvocableType = definition.InvocableType;
+            row.Payload = definition.Payload;
+            row.TimeZoneId = definition.TimeZoneId;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var row = await db.Schedules.FindAsync([key], cancellationToken);
+        if (row is not null)
+        {
+            db.Schedules.Remove(row);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/ScheduleRecord.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/ScheduleRecord.cs
@@ -1,0 +1,11 @@
+namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Scheduling;
+
+/// <summary>The persisted row for a schedule - a flat shape that maps 1:1 to ScheduleDefinition.</summary>
+public class ScheduleRecord
+{
+    public string Key { get; set; } = default!;
+    public string CronExpression { get; set; } = default!;
+    public string InvocableType { get; set; } = default!;
+    public string? Payload { get; set; }
+    public string? TimeZoneId { get; set; }
+}

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/ScheduleStoreDbContext.cs
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/Scheduling/ScheduleStoreDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace DalSoft.Hosting.BackgroundQueue.Examples.WebApi.Scheduling;
+
+/// <summary>
+/// A dedicated context for schedules. It uses its own database so this sample can call EnsureCreated()
+/// independently of the Person example (EnsureCreated is all-or-nothing per database).
+/// </summary>
+public class ScheduleStoreDbContext(DbContextOptions<ScheduleStoreDbContext> options) : DbContext(options)
+{
+    public DbSet<ScheduleRecord> Schedules => Set<ScheduleRecord>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<ScheduleRecord>().HasKey(record => record.Key);
+}

--- a/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/appsettings.json
+++ b/DalSoft.Hosting.BackgroundQueue.Examples.WebApi/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "PersonDbContext": "Server=(localdb)\\mssqllocaldb;Database=BackgroundQueueExample;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "PersonDbContext": "Server=(localdb)\\mssqllocaldb;Database=BackgroundQueueExample;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "ScheduleStoreDbContext": "Server=(localdb)\\mssqllocaldb;Database=BackgroundQueueScheduleStore;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ builder.Services.AddBackgroundJobs();
 
 **The scheduler never polls your database.** The store is read once at startup, written through only when a schedule is added/changed/removed, and otherwise the per-second tick runs entirely against the in-memory schedule. This is deliberate so a pay-per-use / serverless database (e.g. serverless Azure SQL) is never hit while the app is idle. If another process changes schedules directly in the store, call `IJobScheduler.ReloadFromStoreAsync()` to pick them up - ideally from inside a scheduled "sync" job, so even that read happens on your terms.
 
+A complete, drop-in **EF Core / SQL Server `IScheduleStore`** plus runtime add/reschedule/remove endpoints can be found in the [example WebApi](https://github.com/DalSoft/DalSoft.Hosting.BackgroundQueue/tree/master/DalSoft.Hosting.BackgroundQueue.Examples.WebApi) (`Scheduling/EfCoreScheduleStore.cs`). Note it's resolved via `IDbContextFactory<T>` because the store is a singleton and must not capture a scoped `DbContext`.
+
 ### How this compares to Hangfire
 
 This is a *lightweight* alternative, not a replacement for everything Hangfire does. Reach for it when you want in-memory, single-instance scheduling/queuing with minimal dependencies and runtime-editable schedules. Hangfire is the better choice when you need built-in durable storage, automatic retries, a dashboard, or distributed processing across many servers - none of which this library provides out of the box (persistence is bring-your-own, and there's no retry/dashboard/clustering).


### PR DESCRIPTION
Adds a drop-in durable EF Core / SQL Server IScheduleStore and runtime /schedules endpoints to the example WebApi, demonstrating the schedule -> enqueue pattern. Example already targets net8.0.